### PR TITLE
Implement ErrorRelay

### DIFF
--- a/error_relay.py
+++ b/error_relay.py
@@ -1,4 +1,5 @@
 import json
+from functools import wraps
 
 from fastapi import HTTPException
 
@@ -30,7 +31,7 @@ class ErrorRelay:
         """
         Try to decode error from HTTPException.
         """
-        if "ErrorRelay" not in http_exception.headers:
+        if http_exception.headers is None or "ErrorRelay" not in http_exception.headers:
             return None
 
         error = json.loads(http_exception.headers["ErrorRelay"])
@@ -41,3 +42,21 @@ class ErrorRelay:
         error_class = getattr(__import__("builtins"), error_type)
 
         return error_class(error_message)
+
+    @staticmethod
+    def intercept_http_exception(func: callable):
+        """
+        Intercept HTTPException and try decoding error from it.
+        """
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except HTTPException as http_exception:
+                error = ErrorRelay.try_decode_error_from_http_exception(http_exception)
+                if error is not None:
+                    raise error
+                else:
+                    raise http_exception
+        return wrapper
+

--- a/error_relay.py
+++ b/error_relay.py
@@ -1,7 +1,7 @@
 import json
 from functools import wraps
 
-from fastapi import HTTPException
+from starlette.exceptions import HTTPException
 
 
 class ErrorRelay:

--- a/error_relay.py
+++ b/error_relay.py
@@ -20,10 +20,11 @@ class ErrorRelay:
         """
         return HTTPException(
             status_code=400,
-            headers={"ErrorRelay": json.dumps({
-                "type": error.__class__.__name__,
-                "message": str(error)
-            })}
+            headers={
+                "ErrorRelay": json.dumps(
+                    {"type": error.__class__.__name__, "message": str(error)}
+                )
+            },
         )
 
     @staticmethod

--- a/error_relay.py
+++ b/error_relay.py
@@ -1,0 +1,43 @@
+import json
+
+from fastapi import HTTPException
+
+
+class ErrorRelay:
+    """
+    ErrorRelay forwards the error from server to client.
+
+    e.g. When ValueError is raised in server side and is intended to be
+    shown to the user (sending the request with client), ErrorRelay will
+    catch the error and raise it in client side.
+    """
+
+    @staticmethod
+    def encode_error_in_http_exception(error: Exception) -> HTTPException:
+        """
+        Encode error in HTTPException.
+        """
+        return HTTPException(
+            status_code=400,
+            headers={"ErrorRelay": json.dumps({
+                "type": error.__class__.__name__,
+                "message": str(error)
+            })}
+        )
+
+    @staticmethod
+    def try_decode_error_from_http_exception(http_exception: HTTPException) -> Exception | None:
+        """
+        Try to decode error from HTTPException.
+        """
+        if "ErrorRelay" not in http_exception.headers:
+            return None
+
+        error = json.loads(http_exception.headers["ErrorRelay"])
+
+        error_type = error["type"]
+        error_message = error["message"]
+
+        error_class = getattr(__import__("builtins"), error_type)
+
+        return error_class(error_message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+numpy
+torch
+scikit-learn
+starlette

--- a/tests/test_error_relay.py
+++ b/tests/test_error_relay.py
@@ -1,11 +1,26 @@
 import unittest
+from httpx import Response
 
-from fastapi import HTTPException
+from starlette.exceptions import HTTPException
 
 from tabpfn_common_utils.error_relay import ErrorRelay
 
 
 class TestErrorRelay(unittest.TestCase):
+
+    @staticmethod
+    def _get_http_exception_response(encode_error: Exception = None) -> Response:
+        if encode_error is not None:
+            exception = ErrorRelay.encode_error_in_http_exception(encode_error)
+        else:
+            exception = HTTPException(status_code=400)
+
+        response = Response(
+            status_code=400,
+            headers=exception.headers if exception.headers is not None else None,
+        )
+        return response
+
     def test_encode_error_in_http_exception(self):
         error = ValueError("test error")
         http_exception = ErrorRelay.encode_error_in_http_exception(error)
@@ -14,27 +29,27 @@ class TestErrorRelay(unittest.TestCase):
 
     def test_try_decode_error_from_http_exception(self):
         error = ValueError("test error")
-        http_exception = ErrorRelay.encode_error_in_http_exception(error)
-        decoded_error = ErrorRelay.try_decode_error_from_http_exception(http_exception)
+        response = self._get_http_exception_response(encode_error=error)
+        decoded_error = ErrorRelay.try_decode_error_from_http_response(response)
         self.assertEqual(type(decoded_error), ValueError)
         self.assertEqual(str(decoded_error), "test error")
 
-    def test_intercept_http_exception_on_http_exception_containing_value_error(self):
-        def raise_http_exception_containing_value_error():
-            raise ErrorRelay.encode_error_in_http_exception(ValueError())
-
-        @ErrorRelay.intercept_http_exception
-        def calling_func():
-            raise_http_exception_containing_value_error()
-
-        self.assertRaises(ValueError, calling_func)
-
-    def test_intercept_http_exception_on_http_exception_not_containing_error(self):
-        def raise_http_exception_not_containing_error():
-            raise HTTPException(status_code=400)
-
-        @ErrorRelay.intercept_http_exception
-        def calling_func():
-            raise_http_exception_not_containing_error()
-
-        self.assertRaises(HTTPException, calling_func)
+    # def test_intercept_http_exception_on_http_exception_containing_value_error(self):
+    #     def raise_http_exception_containing_value_error():
+    #         raise ErrorRelay.encode_error_in_http_exception(ValueError())
+    #
+    #     @ErrorRelay.intercept_http_exception
+    #     def calling_func():
+    #         raise_http_exception_containing_value_error()
+    #
+    #     self.assertRaises(ValueError, calling_func)
+    #
+    # def test_intercept_http_exception_on_http_exception_not_containing_error(self):
+    #     def raise_http_exception_not_containing_error():
+    #         raise HTTPException(status_code=400)
+    #
+    #     @ErrorRelay.intercept_http_exception
+    #     def calling_func():
+    #         raise_http_exception_not_containing_error()
+    #
+    #     self.assertRaises(HTTPException, calling_func)

--- a/tests/test_error_relay.py
+++ b/tests/test_error_relay.py
@@ -1,0 +1,18 @@
+import unittest
+
+from tabpfn_common_utils.error_relay import ErrorRelay
+
+
+class TestErrorRelay(unittest.TestCase):
+    def test_encode_error_in_http_exception(self):
+        error = ValueError("test error")
+        http_exception = ErrorRelay.encode_error_in_http_exception(error)
+        self.assertEqual(http_exception.status_code, 400)
+        self.assertEqual(http_exception.headers["ErrorRelay"], '{"type": "ValueError", "message": "test error"}')
+
+    def test_try_decode_error_from_http_exception(self):
+        error = ValueError("test error")
+        http_exception = ErrorRelay.encode_error_in_http_exception(error)
+        decoded_error = ErrorRelay.try_decode_error_from_http_exception(http_exception)
+        self.assertEqual(type(decoded_error), ValueError)
+        self.assertEqual(str(decoded_error), "test error")

--- a/tests/test_error_relay.py
+++ b/tests/test_error_relay.py
@@ -33,23 +33,3 @@ class TestErrorRelay(unittest.TestCase):
         decoded_error = ErrorRelay.try_decode_error_from_http_response(response)
         self.assertEqual(type(decoded_error), ValueError)
         self.assertEqual(str(decoded_error), "test error")
-
-    # def test_intercept_http_exception_on_http_exception_containing_value_error(self):
-    #     def raise_http_exception_containing_value_error():
-    #         raise ErrorRelay.encode_error_in_http_exception(ValueError())
-    #
-    #     @ErrorRelay.intercept_http_exception
-    #     def calling_func():
-    #         raise_http_exception_containing_value_error()
-    #
-    #     self.assertRaises(ValueError, calling_func)
-    #
-    # def test_intercept_http_exception_on_http_exception_not_containing_error(self):
-    #     def raise_http_exception_not_containing_error():
-    #         raise HTTPException(status_code=400)
-    #
-    #     @ErrorRelay.intercept_http_exception
-    #     def calling_func():
-    #         raise_http_exception_not_containing_error()
-    #
-    #     self.assertRaises(HTTPException, calling_func)

--- a/tests/test_error_relay.py
+++ b/tests/test_error_relay.py
@@ -1,5 +1,7 @@
 import unittest
 
+from fastapi import HTTPException
+
 from tabpfn_common_utils.error_relay import ErrorRelay
 
 
@@ -16,3 +18,23 @@ class TestErrorRelay(unittest.TestCase):
         decoded_error = ErrorRelay.try_decode_error_from_http_exception(http_exception)
         self.assertEqual(type(decoded_error), ValueError)
         self.assertEqual(str(decoded_error), "test error")
+
+    def test_intercept_http_exception_on_http_exception_containing_value_error(self):
+        def raise_http_exception_containing_value_error():
+            raise ErrorRelay.encode_error_in_http_exception(ValueError())
+
+        @ErrorRelay.intercept_http_exception
+        def calling_func():
+            raise_http_exception_containing_value_error()
+
+        self.assertRaises(ValueError, calling_func)
+
+    def test_intercept_http_exception_on_http_exception_not_containing_error(self):
+        def raise_http_exception_not_containing_error():
+            raise HTTPException(status_code=400)
+
+        @ErrorRelay.intercept_http_exception
+        def calling_func():
+            raise_http_exception_not_containing_error()
+
+        self.assertRaises(HTTPException, calling_func)

--- a/tests/test_error_relay.py
+++ b/tests/test_error_relay.py
@@ -7,7 +7,6 @@ from tabpfn_common_utils.error_relay import ErrorRelay
 
 
 class TestErrorRelay(unittest.TestCase):
-
     @staticmethod
     def _get_http_exception_response(encode_error: Exception = None) -> Response:
         if encode_error is not None:
@@ -25,7 +24,10 @@ class TestErrorRelay(unittest.TestCase):
         error = ValueError("test error")
         http_exception = ErrorRelay.encode_error_in_http_exception(error)
         self.assertEqual(http_exception.status_code, 400)
-        self.assertEqual(http_exception.headers["ErrorRelay"], '{"type": "ValueError", "message": "test error"}')
+        self.assertEqual(
+            http_exception.headers["ErrorRelay"],
+            '{"type": "ValueError", "message": "test error"}',
+        )
 
     def test_try_decode_error_from_http_exception(self):
         error = ValueError("test error")

--- a/utils.py
+++ b/utils.py
@@ -26,9 +26,10 @@ def serialize_to_csv_formatted_bytes(
     return csv_bytes
 
 
+FileCategory = str
 FileName = str
 FileContent = bytes
-FileUpload = typing.Tuple[FileName, FileContent]
+FileUpload = typing.Tuple[FileCategory, FileName, FileContent]
 
 
 def to_httpx_post_file_format(file_uploads: typing.List[FileUpload]) -> typing.Dict:


### PR DESCRIPTION
## Development
**ErrorRelay**
- used by the server to generate `HTTPException` that encodes the `Exception` raised during tabpfn prediction.
- used by the client to decode the HTTP `Response` to extract the error raised in the server.

## Example
The following demonstrates the behavior when the client calls predict with conflicting dataset:
``` python
# Load data
from sklearn.datasets import load_breast_cancer, load_digits
from sklearn.model_selection import train_test_split

breast_X, breast_y = load_breast_cancer(return_X_y=True)
breast_X_train, breast_X_test, breast_y_train, breast_y_test = train_test_split(X, y)
digits_X, digits_y = load_digits(return_X_y=True)
digits_X_train, digits_X_test, digits_y_train, digits_y_test = train_test_split(digits_X, digits_y)

# Init TabPFN
from tabpfn_client import tabpfn_classifier
tabpfn_classifier.init(use_server=True)

# Predict with TabPFN
from tabpfn_client import TabPFNClassifier

tabpfn = TabPFNClassifier()
tabpfn.fit(breast_X_train, breast_y_train)
tabpfn.predict(digits_X_test)
```

Outcome at the client:
<img width="969" alt="image" src="https://github.com/liam-sbhoo/tabpfn_common_utils/assets/44376667/8a9b791e-da4c-48a8-ae40-ec792b341c7a">
