### PR TITLE
Remove torch dependency

### DIFF
--- a/load_test.py
+++ b/load_test.py
@@ -116,7 +116,7 @@ def process_user(user, SERVER_URL):
 
     # Register API: Registers a new user
     register_api = SERVER_URL + ENDPOINTS.register.path
-    response_register = api_request(register_api, user_data, type=RequestType.REGISTER)
+    _ = api_request(register_api, user_data, type=RequestType.REGISTER)
     # print(response_register)
 
     # Login API: Authenticates the user JUST REGISTERED
@@ -129,7 +129,7 @@ def process_user(user, SERVER_URL):
     user_access_token = response_login["access_token"]
     headers = {"Authorization": f"Bearer {user_access_token}"}
     protected_api = SERVER_URL + ENDPOINTS.protected_root.path
-    response_protected = api_request(
+    _ = api_request(
         protected_api, headers=headers, type=RequestType.PROTECTED_ROOT
     )
     # print(response_protected)

--- a/load_test.py
+++ b/load_test.py
@@ -3,7 +3,11 @@ import os.path
 
 sys.path.append("../")
 from pathlib import Path
-import os, random, uuid, requests, argparse
+import os
+import random
+import uuid
+import requests
+import argparse
 from app.main import ENDPOINTS
 from enum import Enum
 from utils import to_oauth_request_form

--- a/regression_pred_result.py
+++ b/regression_pred_result.py
@@ -1,7 +1,4 @@
-from typing import Union
-
 import numpy as np
-import torch
 
 
 class RegressionPredictResult:
@@ -11,10 +8,8 @@ class RegressionPredictResult:
         self.mode = res["mode"]
         self.quantiles = {k: v for k, v in res.items() if k.startswith("quantile_")}
 
-        # assume values are either all numpy arrays or all torch tensors
-        if isinstance(self.mean, torch.Tensor):
-            self._val_type = torch.Tensor
-        elif isinstance(self.mean, np.ndarray):
+        # assume values are either all numpy arrays or lists
+        if isinstance(self.mean, np.ndarray):
             self._val_type = np.ndarray
         elif isinstance(self.mean, list):
             self._val_type = list
@@ -34,10 +29,7 @@ class RegressionPredictResult:
         if res.val_type == list:
             return res
 
-        if res.val_type == torch.Tensor:
-            serialize_fn = torch.Tensor.tolist
-        else:
-            serialize_fn = np.ndarray.tolist
+        serialize_fn = np.ndarray.tolist
 
         return {
             "mean": serialize_fn(res.mean),
@@ -47,15 +39,8 @@ class RegressionPredictResult:
         }
 
     @staticmethod
-    def from_basic_representation(
-        basic_repr: dict[str, list],
-        output_val_type: Union[np.ndarray, torch.Tensor]
-    ) -> dict[str, Union[np.ndarray, torch.Tensor]]:
-
-        if output_val_type == torch.Tensor:
-            deserialize_fn = torch.tensor
-        else:
-            deserialize_fn = np.array
+    def from_basic_representation(basic_repr: dict[str, list]) -> dict[str, np.ndarray]:
+        deserialize_fn = np.array
 
         return {
             "mean": deserialize_fn(basic_repr["mean"]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,6 @@ from io import BytesIO
 
 import numpy as np
 import pandas as pd
-import torch
 
 from tabpfn_common_utils import utils
 
@@ -21,13 +20,6 @@ class TestDataSerialization(unittest.TestCase):
         csv_bytes = utils.serialize_to_csv_formatted_bytes(test_data)
         data_recovered = pd.read_csv(BytesIO(csv_bytes), delimiter=",")
         pd.testing.assert_frame_equal(test_data, data_recovered)
-
-    def test_serialize_torch_tensor_to_csv_formatted_bytes(self):
-        test_data = torch.tensor([[1, 2, 3], [4, 5, 6]], dtype=torch.float64)
-        test_pd_data = pd.DataFrame(test_data.numpy(), columns=["0", "1", "2"])
-        csv_bytes = utils.serialize_to_csv_formatted_bytes(test_data)
-        data_recovered = pd.read_csv(BytesIO(csv_bytes), delimiter=",")
-        pd.testing.assert_frame_equal(test_pd_data, data_recovered)
 
 
 class TestSingleton(unittest.TestCase):

--- a/utils.py
+++ b/utils.py
@@ -64,13 +64,13 @@ def get_example_dataset(
         "diabetes": load_diabetes,
     }
     x_train, y_train = load_dataset_fn[dataset_name](return_X_y=True, as_frame=True)
-    
+
     # shuffle and get 10 examples
     # shuffle is needed because we will might get examples with only 1 class
     indices = np.random.permutation(len(x_train))[:10]
     x_train = x_train.iloc[indices]
     y_train = y_train.iloc[indices]
-    
+
     x_train, x_test, y_train, y_test = train_test_split(
         x_train, y_train, test_size=0.33, random_state=42
     )

--- a/utils.py
+++ b/utils.py
@@ -3,19 +3,15 @@ from functools import wraps
 
 import pandas as pd
 import numpy as np
-import torch
 from sklearn.datasets import load_breast_cancer, load_digits, load_iris, load_diabetes
 from sklearn.model_selection import train_test_split
 
 
 def serialize_to_csv_formatted_bytes(
-    data: typing.Union[pd.DataFrame, pd.Series, np.ndarray, torch.Tensor],
+    data: typing.Union[pd.DataFrame, pd.Series, np.ndarray],
 ) -> bytes:
-    if type(data) not in [pd.DataFrame, pd.Series, np.ndarray, torch.Tensor]:
+    if type(data) not in [pd.DataFrame, pd.Series, np.ndarray]:
         raise TypeError(f"({type(data)}) is not supported for serialization")
-
-    if isinstance(data, torch.Tensor):
-        data = data.numpy()
 
     if isinstance(data, np.ndarray):
         data = pd.DataFrame(data)
@@ -68,8 +64,13 @@ def get_example_dataset(
         "diabetes": load_diabetes,
     }
     x_train, y_train = load_dataset_fn[dataset_name](return_X_y=True, as_frame=True)
-    x_train = x_train[:100]
-    y_train = y_train[:100]
+    
+    # shuffle and get 10 examples
+    # shuffle is needed because we will might get examples with only 1 class
+    indices = np.random.permutation(len(x_train))[:10]
+    x_train = x_train.iloc[indices]
+    y_train = y_train.iloc[indices]
+    
     x_train, x_test, y_train, y_test = train_test_split(
         x_train, y_train, test_size=0.33, random_state=42
     )


### PR DESCRIPTION
### Change Description

**Brief** (a few bullet points describing your changes, use full sentences and try to link lines in the code whenever needed)

- remove torch dependency entire from this library
  - torch was initially needed because we want to support the serialization of torch tensor.
  - by limiting RegressionPredictResult to support numpy only, we effectively remove torch.
  - torch is only required in Vertex AI

**Details** (add details if your pull request is more complicated and harder to understand from the code alone)



### Standard Qs (leave questions that do not apply blank)
**If you broke behavior: Please describe what behavior you broke and how you inform people to not get stuck trying to use the old behavior.**



**If you used new dependencies: Did you add them to `requirements.txt`?**



**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**



---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
